### PR TITLE
Complete initial workflow before new one

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -41,12 +41,15 @@ env:
   MAIL_BODY: Testing GH Actions workflow
   PR_ID: ${{ github.event.number }}
   BRANCH_NAME: ${{ github.base_ref }}
+  SAVED_MODELS_PATH: "/usr/share/migraphx/saved-models"
+  REPORTS_PATH: "/usr/share/migraphx/reports"
+  TEST_RESULTS_PATH: "/usr/share/migraphx/test-results"
+  MIGRAPHX_PATH: "/usr/share/migraphx"
 
 jobs:
-  build_image:
-    name: Build MiGraphX Image
+  performance_test:
+    name: MIGraphX Performance
     runs-on: self-hosted
-    if: ${{ github.event.action != 'closed' }}
     outputs:
       git_sha: ${{ steps.git_sha.outputs.git_sha }}
     steps:
@@ -54,21 +57,27 @@ jobs:
         if: ${{ github.event_name == 'pull_request'}}
         run: |
           echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Checkout Utils
+
+      - name: Checkout utils
         uses: actions/checkout@v3
         with:
           repository: "migraphx-benchmark/benchmark-utils"
           path: ${{ env.UTILS_DIR }}
           token: ${{ secrets.gh_token }}
+
       - name: Get git SHA
         id: git_sha
         run: |
           cd $GITHUB_WORKSPACE
           SHA=$(git log | head -1 | awk '{print $2}' | cut -c 1-6)
           echo "::set-output name=git_sha::$SHA"
+
       - name: Docker build
+        if: ${{ github.event.action != 'closed' }}
         run: >
           cd $GITHUB_WORKSPACE/${{ env.UTILS_DIR }} && docker build --no-cache
           --build-arg BRANCH=${{ env.BRANCH_NAME }} 
@@ -77,29 +86,8 @@ jobs:
           -t "migraphx-rocm:${{ inputs.rocm_release }}-${{ steps.git_sha.outputs.git_sha }}" 
           -f dockerfiles/Daily.Dockerfile .
 
-  execute_scripts:
-    name: Execute scripts
-    runs-on: self-hosted
-    if: ${{ github.event.action != 'closed' }}
-    needs: build_image
-    env:
-      SAVED_MODELS_PATH: "/usr/share/migraphx/saved-models"
-      REPORTS_PATH: "/usr/share/migraphx/reports"
-      TEST_RESULTS_PATH: "/usr/share/migraphx/test-results"
-      MIGRAPHX_PATH: "/usr/share/migraphx"
-    steps:
-      - name: Update PR env
-        if: ${{ github.event_name == 'pull_request'}}
-        run: |
-          echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
-      - name: Checkout Utils
-        uses: actions/checkout@v3
-        with:
-          repository: "migraphx-benchmark/benchmark-utils"
-          path: ${{ env.UTILS_DIR }}
-          token: ${{ secrets.gh_token }}
-
       - name: Run performance tests
+        if: ${{ github.event.action != 'closed' }}
         run: >
           docker run -e TZ=America/Chicago
           -e TARGET=gpu
@@ -111,7 +99,7 @@ jobs:
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           --workdir /migraphx/sh
-          migraphx-rocm:${{ inputs.rocm_release }}-${{ needs.build_image.outputs.git_sha }} /bin/bash performance_tests.sh
+          migraphx-rocm:${{ inputs.rocm_release }}-${{ steps.git_sha.outputs.git_sha }} /bin/bash performance_tests.sh
 
       - name: Delete old images/containers
         if: ${{ github.event_name == 'schedule' }}
@@ -122,6 +110,7 @@ jobs:
           fi
 
       - name: Checkout report's repo
+        if: ${{ github.event_name == 'schedule' }}
         uses: actions/checkout@v3
         with:
           repository: ${{ inputs.performance_reports_repo }}
@@ -146,7 +135,7 @@ jobs:
 
       - name: Execute comment script
         id: auto_comment
-        if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request'}} 
+        if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request' && github.event.action != 'closed'}}
         run: |
           if [ ${{ inputs.flags }} == "-r" ]; then
             flagoptions="${{ inputs.flags }} $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts/"
@@ -156,7 +145,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts/comment.py -t ${TEST_RESULTS_PATH//-$PR_ID/} -n ${{ inputs.result_number }} $flagoptions -p
 
       - name: Create a comment on PR
-        if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request'}}
+        if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request' && github.event.action != 'closed'}}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           GITHUB_TOKEN: ${{ secrets.gh_token }}
@@ -187,23 +176,21 @@ jobs:
           ignore_cert: true
           attachments: ${{ steps.last_report.outputs.latest}}
           priority: normal
-  
-  clean_pr_data:
-    name: Clean merged PR data
-    runs-on: self-hosted
-    needs: execute_scripts
-    if: ${{ always() && github.event.action == 'closed' && github.event.pull_request.merged == true}}
-    env:
-      TEST_RESULTS_PATH: "/usr/share/migraphx/test-results"
-      MIGRAPHX_PATH: "/usr/share/migraphx"
-    steps:
-      - name: Update PR env
-        run: |
-          echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
+
       - name: Clean merged PR data
+        if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true}}
         run: >
           docker run
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.MIGRAPHX_PATH }}:/data/migraphx
           --workdir /migraphx/sh
-          rocm-migraphx:${{ inputs.rocm_release }} bash -c "./clean_after_pr.sh ${{ env.TEST_RESULTS_PATH }} ${{ env.PR_ID }}"
+          rocm-migraphx:${{ inputs.rocm_release }} bash -c "./clean_after_pr.sh ${{ env.TEST_RESULTS_PATH }} ${{ env.PR_ID }} merged"
+
+      - name: Clean closed PR data
+        if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == false}}
+        run: >
+          docker run
+          -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
+          -v ${{ env.MIGRAPHX_PATH }}:/data/migraphx
+          --workdir /migraphx/sh
+          rocm-migraphx:${{ inputs.rocm_release }} bash -c "./clean_after_pr.sh ${{ env.TEST_RESULTS_PATH }} ${{ env.PR_ID }} closed"


### PR DESCRIPTION
Updated perf-test.yml workflow has previously implemented multiple jobs merged into one with multiple steps, in order to resolve Github actions scheduler limitations with assigning available runner to random jobs in separate workflows before completing initial workflow.