### PR TITLE
input parameters cleanup

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -108,6 +108,7 @@ jobs:
           --build-arg BRANCH=${{ env.BRANCH_NAME }} 
           --build-arg DOCKERBASE=${{ env.DOCKERBASE }}
           --build-arg MIOPENTUNE=${{ env.MIOPENTUNE }}
+          --build-arg benchmark_utils_repo=${{ inputs.benchmark_utils_repo }}
           -t "migraphx-rocm:${{ inputs.rocm_release }}-${{ steps.git_sha.outputs.git_sha }}" 
           -f dockerfiles/Daily.Dockerfile .
 

--- a/.github/workflows/rocm-release.yml
+++ b/.github/workflows/rocm-release.yml
@@ -10,10 +10,6 @@ on:
         type: string
         description: Repository for benchmark utils
         required: true
-      organization:
-        type: string
-        description: Organization based on which location of files will be different
-        required: true
       base_image:
         type: string
         description: Base image for rocm Docker build


### PR DESCRIPTION
perf-test.yaml ---> added build argument for benchmark utils repository
rocm-release.yaml ---> removed organization parameter since it is not used

This PR has to be merged with next PR's in order not to break any functionality:
1. https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/pull/1777
2. https://github.com/ROCmSoftwarePlatform/migraphx-benchmark-utils/pull/26