### PR TITLE
Use rbuild

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -118,7 +118,7 @@ jobs:
           docker run -e TZ=America/Chicago
           -e TARGET=gpu
           -e PYTHONPATH=/src/AMDMIGraphX/build/lib
-		  -e USE_RBUILD=1
+          -e USE_RBUILD=1
           --device=/dev/dri
           --device=/dev/kfd
           --network=host

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -118,6 +118,7 @@ jobs:
           docker run -e TZ=America/Chicago
           -e TARGET=gpu
           -e PYTHONPATH=/src/AMDMIGraphX/build/lib
+		  -e USE_RBUILD=1
           --device=/dev/dri
           --device=/dev/kfd
           --network=host


### PR DESCRIPTION
Better to use rbuild, it would add and build  dependencies as we change requirements.txt file. 
For example, https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/pull/1791 added CK but it is not pulled currently inside Performance tests docker. 
